### PR TITLE
Harden ODL serializer and document ODL troubleshooting

### DIFF
--- a/backend/odl/serializer.py
+++ b/backend/odl/serializer.py
@@ -12,7 +12,7 @@ Notes:
 - This is intentionally simple so it's easy to diff and copy/paste.
 """
 from __future__ import annotations
-from typing import Dict, Any, Iterable
+from typing import Dict, Any, Iterable, Iterator
 
 
 def _fmt_attrs(attrs: Dict[str, Any] | None) -> str:
@@ -31,24 +31,38 @@ def _fmt_attrs(attrs: Dict[str, Any] | None) -> str:
     return " [" + " ".join(parts) + "]"
 
 
+def _iter_nodes(nodes: Iterable[Any] | None) -> Iterator[Dict[str, Any]]:
+    """Yield dict-like nodes, skipping anything malformed."""
+    for n in nodes or []:
+        if isinstance(n, dict):
+            yield n
+
+
+def _iter_edges(edges: Iterable[Any] | None) -> Iterator[Dict[str, Any]]:
+    """Yield dict-like edges, skipping anything malformed."""
+    for e in edges or []:
+        if isinstance(e, dict):
+            yield e
+
+
 def view_to_odl(view: Dict[str, Any]) -> str:
     nodes: Iterable[Dict[str, Any]] = sorted(
-        view.get("nodes") or [],
-        key=lambda n: (n.get("type", ""), n.get("id", "")),
+        _iter_nodes(view.get("nodes")),
+        key=lambda n: (n.get("type") or "", n.get("id") or ""),
     )
     edges: Iterable[Dict[str, Any]] = sorted(
-        view.get("edges") or [],
-        key=lambda e: (e.get("source", ""), e.get("target", "")),
+        _iter_edges(view.get("edges")),
+        key=lambda e: (e.get("source") or "", e.get("target") or ""),
     )
     lines = ["# ODL (canonical text)"]
     for n in nodes:
         nid = n.get("id", "")
         ntype = n.get("type") or "generic"
-        attrs = n.get("attrs") or {}
+        attrs = n.get("attrs") if isinstance(n.get("attrs"), dict) else {}
         lines.append(f"node {nid} : {ntype}{_fmt_attrs(attrs)}")
     for e in edges:
         src = e.get("source", "")
         tgt = e.get("target", "")
-        attrs = e.get("attrs") or {}
+        attrs = e.get("attrs") if isinstance(e.get("attrs"), dict) else {}
         lines.append(f"link {src} -> {tgt}{_fmt_attrs(attrs)}")
     return "\n".join(lines) + "\n"

--- a/docs/ODL_TROUBLESHOOTING.md
+++ b/docs/ODL_TROUBLESHOOTING.md
@@ -1,0 +1,36 @@
+# Troubleshooting ODL Canvas and CORS Errors
+
+When the canvas renders blank nodes or the browser shows CORS or 500 errors
+for `/api/v1/odl/.../text` or `/view`, use this checklist to debug.
+
+1. **CORS configuration (development)**
+   Make sure the backend allows the frontend origin:
+   ```bash
+   export ORIGINFLOW_CORS_ORIGINS="http://localhost:8082,http://127.0.0.1:8082,*"
+   poetry run uvicorn backend.main:app --reload --host 0.0.0.0
+   ```
+2. **Create a session**
+   ```bash
+   curl -s -X POST 'http://localhost:8000/api/v1/odl/sessions?session_id=demo'
+   ```
+3. **Plan and apply nodes**
+   ```bash
+   curl -s -X POST 'http://localhost:8000/api/v1/ai/act' \
+     -H 'Content-Type: application/json' -H 'If-Match: 1' \
+     -d '{"session_id":"demo","task":"make_placeholders","request_id":"r1",
+          "args":{"component_type":"inverter","count":1,"layer":"single-line"}}'
+   ```
+4. **Verify view positions**
+   ```bash
+   curl -s 'http://localhost:8000/api/v1/odl/demo/view?layer=single-line' | jq '.nodes[0]'
+   ```
+   Each node should include a `pos: {x,y}` block, which the backend computes on
+   the fly if missing.
+5. **ODL text endpoint**
+   ```bash
+   curl -s -i 'http://localhost:8000/api/v1/odl/sessions/demo/text?layer=single-line'
+   ```
+   The response should be `200` and contain either canonical or fallback text.
+
+If any step fails, tail the backend logs. The serializer and layout helpers are
+resilient, so persistent errors usually point to deeper store or data issues.


### PR DESCRIPTION
## Summary
- Make ODL text serializer skip malformed nodes and edges to avoid crashes
- Add troubleshooting guide for canvas/CORS issues and verifying ODL endpoints

## Testing
- `ruff check backend/odl/serializer.py`
- `pytest tests/test_edge_router_builtin.py` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68a7b9b7d1e88329b404d37c63f81865