### PR TITLE
Fetch graph view and mirror position fields for ODL canvas

### DIFF
--- a/backend/api/routes/odl.py
+++ b/backend/api/routes/odl.py
@@ -150,6 +150,11 @@ async def get_view(
             n.setdefault("attrs", {})
             n["attrs"].setdefault("layer", layer_name)
         view = ensure_positions(view)
+        for n in (view.get("nodes") or []):
+            if "position" not in n and "pos" in n:
+                n["position"] = n["pos"]
+            if "pos" not in n and "position" in n:
+                n["pos"] = n["position"]
         logger.info(
             "ODL /view sid=%s layer=%s nodes=%d edges=%d",
             session_id, layer_name, len(view.get("nodes") or []), len(view.get("edges") or []),

--- a/backend/odl/layout.py
+++ b/backend/odl/layout.py
@@ -10,8 +10,27 @@ def ensure_positions(view: Dict[str, Any]) -> Dict[str, Any]:
         return view
 
     # Detect if at least one node already has a usable position
-    if any(("x" in n or "y" in n or ("pos" in n and isinstance(n["pos"], dict))) for n in nodes):
-        return view  # nothing to do
+    if any(
+        (
+            "x" in n
+            or "y" in n
+            or ("pos" in n and isinstance(n["pos"], dict))
+            or ("position" in n and isinstance(n["position"], dict))
+        )
+        for n in nodes
+    ):
+        # Mirror position/pos keys without mutating input
+        out = dict(view)
+        out_nodes: List[Dict[str, Any]] = []
+        out["nodes"] = out_nodes
+        for n in nodes:
+            m = dict(n)
+            if "position" in m and "pos" not in m and isinstance(m["position"], dict):
+                m["pos"] = dict(m["position"])
+            if "pos" in m and "position" not in m and isinstance(m["pos"], dict):
+                m["position"] = dict(m["pos"])
+            out_nodes.append(m)
+        return out
 
     # Create a shallow copy of the view and nodes to avoid mutating store output
     out = dict(view)
@@ -31,5 +50,8 @@ def ensure_positions(view: Dict[str, Any]) -> Dict[str, Any]:
             m["pos"].setdefault("y", y)
         else:
             m["pos"] = {"x": x, "y": y}
+        # Mirror to position alias
+        if "position" not in m:
+            m["position"] = dict(m["pos"])
         out_nodes.append(m)
     return out

--- a/docs/troubleshooting/blank-canvas.md
+++ b/docs/troubleshooting/blank-canvas.md
@@ -1,0 +1,15 @@
+## Canvas renders nothing, ODL tab shows nodes
+
+**Symptom**: ODL Code tab shows nodes/versions increasing, but the Single-Line canvas is empty.
+
+**Checklist**
+1. Confirm the frontend is requesting the view: look for `GET /api/v1/odl/{sid}/view?layer=...` in backend logs.
+2. If only `/text` is hit, wire the UI to call `/view` when the active layer or `graphVersion` changes.
+3. Ensure nodes have positions: backend should include `position` (and `pos`) for each node.
+4. If you’ve added new node types, verify the canvas registers them or falls back to a default node.
+5. Use `curl` to sanity-check:
+   ```bash
+   curl -s "http://localhost:8000/api/v1/odl/<sid>/view?layer=single-line" | jq '.nodes | length'
+   ```
+   A non-zero value means data exists; focus on the frontend.
+

--- a/frontend/src/components/Workspace.tsx
+++ b/frontend/src/components/Workspace.tsx
@@ -169,17 +169,18 @@ const Workspace: React.FC = () => {
     addComponent,
     updateComponentPosition,
     addLink,
-    fetchProject,
+    refreshGraphView,
     selectedComponentId,
     deleteComponent,
     currentLayer,
     sessionId, // Use the main sessionId for ODL view
+    graphVersion,
     canvasComponents,
     links,
   } = useAppStore();
   useEffect(() => {
-    fetchProject();
-  }, [fetchProject]);
+    refreshGraphView();
+  }, [refreshGraphView, sessionId, currentLayer, graphVersion]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -558,7 +558,7 @@ export const api = {
   },
 
   /** Get ODL text representation, with /view fallback */
-    async getOdlText(
+  async getOdlText(
       sessionId: string,
       layer: string = 'single-line',
     ): Promise<{
@@ -614,6 +614,16 @@ export const api = {
         return { version: 0 };
       }
     },
+
+  // Fetch the structured graph view used for rendering the canvas
+  async getGraphView(sessionId: string, layer: string = 'single-line') {
+    layer = canonicalLayer(layer);
+    const res = await fetch(
+      `${API_BASE_URL}/odl/${encodeURIComponent(sessionId)}/view?layer=${encodeURIComponent(layer)}`
+    );
+    if (!res.ok) throw new Error(`getGraphView failed: ${res.status}`);
+    return res.json();
+  },
 
   /** Get debug information for an ODL session */
   async debugOdlSession(sessionId: string, layer: string = 'single-line') {


### PR DESCRIPTION
## Summary
- Mirror `pos` and `position` in ODL view responses to keep node coordinates compatible
- Track and refresh structured graph view on the frontend to populate the canvas
- Document troubleshooting steps for an empty canvas

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c7c1aa2c83299e2353316dfb2a86