### PR TITLE
Add canvas clearing intent and task execution controls

### DIFF
--- a/backend/tools/deletion.py
+++ b/backend/tools/deletion.py
@@ -13,10 +13,15 @@ from backend.tools.schemas import DeleteNodesInput, make_patch
 def delete_nodes(inp: DeleteNodesInput):
     """Return an ODLPatch that removes nodes matching component types."""
     targets = {t.lower() for t in inp.component_types}
+    delete_all = not targets or "*" in targets
     ops: List[PatchOp] = []
     for node in inp.view_nodes:
         ntype = (node.type or "").lower()
-        if ntype in targets:
+        if delete_all or ntype in targets:
             op_id = f"{inp.request_id}:rm:{node.id}"
             ops.append(PatchOp(op_id=op_id, op="remove_node", value={"id": node.id}))
+
+    print(
+        f"[delete_nodes] removed={len(ops)} delete_all={delete_all} targets={sorted(targets)}"
+    )
     return make_patch(inp.request_id, ops)

--- a/frontend/src/components/ChatInputArea.tsx
+++ b/frontend/src/components/ChatInputArea.tsx
@@ -11,6 +11,8 @@ const ChatInputArea = () => {
   const setInput = useAppStore((s) => s.setChatDraft);
   const analyzeAndExecute = useAppStore((s) => s.analyzeAndExecute);
   const clearChatDraft = useAppStore((s) => s.clearChatDraft);
+  const planTasks = useAppStore((s) => s.planTasks);
+  const runNextPlanTask = useAppStore((s) => s.runNextPlanTask);
   const voiceMode = useAppStore((s) => s.voiceMode);
   const startListening = useAppStore((s) => s.startListening);
   const stopListening = useAppStore((s) => s.stopListening);
@@ -27,7 +29,12 @@ const ChatInputArea = () => {
 
   const handleSend = async () => {
     const trimmed = input.trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      const pending = planTasks.find((t) => t.status === 'pending');
+      if (pending) await runNextPlanTask();
+      clearChatDraft();
+      return;
+    }
     const normalized = trimmed.toLowerCase();
     if (
       activeDatasheet &&

--- a/frontend/src/components/ODLCodeView.tsx
+++ b/frontend/src/components/ODLCodeView.tsx
@@ -71,10 +71,10 @@ export const ODLCodeView: React.FC<ODLCodeViewProps> = ({ sessionId }) => {
   // Auto-refresh every 5 seconds when enabled
   useEffect(() => {
     if (!autoRefresh) return;
-    
-    const interval = setInterval(fetchODLText, 5000);
-    return () => clearInterval(interval);
-  }, [autoRefresh, fetchODLText]);
+
+    const id = setInterval(fetchODLText, 5000);
+    return () => clearInterval(id);
+  }, [autoRefresh, fetchODLText, sessionId]);
 
   const handleRefresh = () => {
     fetchODLText();


### PR DESCRIPTION
## Summary
- handle "delete all" and similar phrases in planner
- allow deletion tool to clear entire layer via wildcard
- split planning from execution so empty sends run next task
- clean up ODL code view interval timers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test --prefix frontend`
- `npm run lint --prefix frontend`
- `npm run type-check --prefix frontend` *(fails: TS2345 etc)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d4e275cc8329818f6fae018521cc