### PR TITLE
feat: use task args during plan execution

### DIFF
--- a/frontend/src/appStore.ts
+++ b/frontend/src/appStore.ts
@@ -98,6 +98,8 @@ export interface PlanTask {
   description?: string;
   /** Current execution status. */
   status: PlanTaskStatus;
+  /** Arguments required to execute this task. */
+  args?: Record<string, any>;
 }
 
 /**
@@ -580,10 +582,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     const execute = async (retry = false): Promise<PlanTaskStatus> => {
       try {
-        const { patch, card, status, version } = await api.act(
+        const { patch, card, status, version, updated_tasks } = await api.act(
           sessionId,
           task.id,
-          undefined,
+          task.args,
           get().graphVersion
         );
         if (typeof version === 'number') set({ graphVersion: version });
@@ -606,28 +608,18 @@ export const useAppStore = create<AppState>((set, get) => ({
         const newStatus = (status as PlanTaskStatus) || 'complete';
         get().updatePlanTaskStatus(task.id, newStatus);
 
-        // After completing a task, refresh the plan from the server to ensure the UI
-        // reflects the latest list of tasks.  This prevents stale or duplicate tasks
-        // from persisting in the timeline when the backend updates the plan.
-        try {
-          const refreshedPlan = await api.getPlanForSession(
-            sessionId,
-            get().lastPrompt || 'design',
-            get().currentLayer
-          );
-          if (
-            (refreshedPlan as any).tasks &&
-            Array.isArray((refreshedPlan as any).tasks)
-          ) {
-            set({ planTasks: (refreshedPlan as any).tasks as any });
-          }
-          // After refreshing the plan, synchronise the graph version so that
-          // subsequent act requests carry the correct version number.
-          await (get() as any).syncGraphVersion(sessionId);
-          await (get() as any).refreshGraphView();
-        } catch (e) {
-          console.warn('Failed to refresh plan after act', e);
+        if (Array.isArray(updated_tasks)) {
+          set({
+            planTasks: updated_tasks.map((t: any) => ({
+              id: t.id,
+              title: t.title,
+              description: t.reason || t.description,
+              status: t.status,
+              args: (t as any).args,
+            })),
+          });
         }
+        await (get() as any).refreshGraphView();
 
         return newStatus;
       } catch (err: any) {
@@ -646,7 +638,15 @@ export const useAppStore = create<AppState>((set, get) => ({
               get().currentLayer
             );
             if ((plan as any).tasks && Array.isArray((plan as any).tasks))
-              set({ planTasks: (plan as any).tasks as any });
+              set({
+                planTasks: (plan as any).tasks.map((t: any) => ({
+                  id: t.id,
+                  title: t.title,
+                  description: t.description,
+                  status: t.status ?? 'pending',
+                  args: (t as any).args,
+                })),
+              });
             // After refetching the plan, sync the graph version to avoid
             // another conflict when we retry the act call.
             await (get() as any).syncGraphVersion(sessionId);
@@ -1096,6 +1096,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     addMessage({ id: crypto.randomUUID(), author: 'User', text: command });
     setIsAiProcessing(true);
     get().addStatusMessage('Processing command', 'info');
+    // Clear any existing plan so stale tasks aren't shown while fetching new ones
+    setPlanTasks([]);
 
     try {
       const sessionId = (get() as any).sessionId || 'global';
@@ -1115,18 +1117,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       // Sync the graph version so the first act call uses the current version
       await (get() as any).syncGraphVersion(get().sessionId);
       if (plan.tasks && Array.isArray(plan.tasks)) {
-        // Merge new tasks with existing ones, preserving their statuses
-        const existingTasks = get().planTasks;
-        const merged: PlanTask[] = plan.tasks.map((t: any) => {
-          const existing = existingTasks.find((et) => et.id === t.id);
-          return {
-            id: t.id,
-            title: t.title,
-            description: t.description,
-            status: existing ? existing.status : ((t.status ?? 'pending') as any),
-          };
-        });
-        setPlanTasks(merged);
+        setPlanTasks(
+          plan.tasks.map(
+            (t: any) => ({
+              id: t.id,
+              title: t.title,
+              description: t.description,
+              status: (t.status ?? 'pending') as any,
+              args: (t as any).args,
+            })
+          )
+        );
       }
       if (plan.quick_actions && Array.isArray(plan.quick_actions)) {
         setQuickActions(

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -14,7 +14,13 @@ import { CanvasComponent, Link, PlanTask } from '../appStore';
 import { API_BASE_URL } from '../config';
 
 export type AiPlan = {
-  tasks: { id: string; title: string; description?: string; status: 'pending' | 'in_progress' | 'complete' | 'blocked' }[];
+  tasks: {
+    id: string;
+    title: string;
+    description?: string;
+    status: 'pending' | 'in_progress' | 'complete' | 'blocked';
+    args?: any;
+  }[];
   metadata?: Record<string, any>;
 };
 
@@ -139,21 +145,21 @@ function fallbackPlanFromPrompt(command: string, layer: string = 'single-line'):
         description: `Add one inverter on the ${layer} layer`,
         status: 'pending',
         args: { component_type: 'inverter', count: 1, layer },
-      } as any,
+      },
       {
         id: 'make_placeholders',
         title: `Create ${count} panels`,
         description: `Add ${count} x ~${panelW}W panels on the ${layer} layer`,
         status: 'pending',
         args: { component_type: 'panel', count, layer },
-      } as any,
+      },
       {
         id: 'generate_wiring',
         title: 'Generate wiring',
         description: `Auto-connect inverter and panels on ${layer} layer`,
         status: 'pending',
         args: { layer },
-      } as any,
+      },
     ],
     metadata: { fallback: true, targetKW, panelW, count, layer },
   };


### PR DESCRIPTION
## Summary
- track arguments with plan tasks and clear stale plan entries on new commands
- send stored task args when calling act and refresh plan from act responses
- simplify timeline execution to call performPlanTask directly

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check` *(fails: 'task.missing_requirements.length' is possibly 'undefined' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7da638bd0832995b421954ccae9e5