### PR TITLE
Add design-state electrical toolchain

### DIFF
--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -6,7 +6,23 @@ access to databases or global stores.  The orchestrator is responsible for
 composing tools and applying the resulting patches.
 """
 
-from . import wiring, structural, monitoring, placeholders, selection, consensus, schemas, replacement, deletion
+from . import (
+    wiring,
+    structural,
+    monitoring,
+    placeholders,
+    selection,
+    consensus,
+    schemas,
+    replacement,
+    deletion,
+    electrical,
+    analysis,
+    standards,
+    components,
+    datasheets,
+    comm,
+)
 
 __all__ = [
     "wiring",
@@ -18,4 +34,10 @@ __all__ = [
     "schemas",
     "replacement",
     "deletion",
+    "electrical",
+    "analysis",
+    "standards",
+    "components",
+    "datasheets",
+    "comm",
 ]

--- a/backend/tools/analysis.py
+++ b/backend/tools/analysis.py
@@ -1,0 +1,95 @@
+"""Analytical helpers for electrical design."""
+from __future__ import annotations
+
+from backend.odl.schemas import PatchOp
+from .schemas import (
+    ApplyBreakerCurveInput,
+    CalcVdropInput,
+    CalcIfaultInput,
+    make_patch,
+)
+
+
+def apply_breaker_curve(inp: ApplyBreakerCurveInput):
+    t = _loglog_interp(inp.breaker_curve.points, inp.current_multiple)
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:curve",
+            op="add_edge",
+            value={
+                "id": f"ann:curve:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "apply_breaker_curve", "result": {"t_trip_s": t}},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+
+
+def _loglog_interp(points, x: float) -> float:
+    pts = sorted(points, key=lambda p: p[0])
+    if x <= pts[0][0]:
+        return pts[0][1]
+    if x >= pts[-1][0]:
+        return pts[-1][1]
+    from math import log10
+
+    for (x1, y1), (x2, y2) in zip(pts, pts[1:]):
+        if x1 <= x <= x2:
+            lx1, lx2 = log10(x1), log10(x2)
+            ly1, ly2 = log10(y1), log10(y2)
+            t = (log10(x) - lx1) / (lx2 - lx1)
+            ly = ly1 + t * (ly2 - ly1)
+            return 10 ** ly
+    return pts[-1][1]
+
+
+def calculate_voltage_drop(inp: CalcVdropInput):
+    if inp.phase == "dc":
+        vd = inp.current_A * inp.R_ohm_per_km * (2 * inp.length_m / 1000)
+    elif inp.phase == "1ph":
+        vd = 2 * inp.current_A * inp.R_ohm_per_km * (inp.length_m / 1000)
+    else:
+        from math import sqrt
+
+        vd = sqrt(3) * inp.current_A * inp.R_ohm_per_km * (inp.length_m / 1000)
+    pct = vd / inp.system_v * 100.0
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:vdrop",
+            op="add_edge",
+            value={
+                "id": f"ann:vdrop:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "calculate_voltage_drop", "result": {"v_drop_V": vd, "v_drop_pct": pct}},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+
+
+def calculate_fault_current(inp: CalcIfaultInput):
+    results = {}
+    if inp.dc_isc_stc and inp.dc_parallel_strings:
+        results["dc_fault_A"] = inp.dc_isc_stc * inp.dc_parallel_strings * inp.dc_multiplier
+    if inp.ac_inverter_inom:
+        results["ac_fault_A"] = inp.ac_inverter_inom * inp.ac_fault_multiple
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:ifault",
+            op="add_edge",
+            value={
+                "id": f"ann:ifault:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "calculate_fault_current", "result": results},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+

--- a/backend/tools/comm.py
+++ b/backend/tools/comm.py
@@ -1,0 +1,28 @@
+"""Communication planning tools."""
+from __future__ import annotations
+
+from backend.odl.schemas import PatchOp
+from .schemas import LinkBudgetPlannerInput, make_patch
+
+
+def link_budget_planner(inp: LinkBudgetPlannerInput):
+    ok = True
+    notes = "RS-485 typical max segment length ~1200 m"
+    if inp.topology == "rs485_multi_drop" and inp.segment_length_m > 1200:
+        ok = False
+        notes = "Segment exceeds RS-485 guidance"
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:link",
+            op="add_edge",
+            value={
+                "id": f"ann:link:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "link_budget_planner", "ok": ok, "notes": notes},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+

--- a/backend/tools/components.py
+++ b/backend/tools/components.py
@@ -1,0 +1,35 @@
+"""Component metadata enrichment."""
+from __future__ import annotations
+
+from backend.odl.schemas import PatchOp
+from .schemas import EnrichComponentMetadataInput, make_patch
+
+
+def enrich_component_metadata(inp: EnrichComponentMetadataInput):
+    out = dict(inp.existing_json)
+    out.update(inp.new_attrs)
+    prov = list(out.get("provenance") or [])
+    if inp.provenance:
+        prov.append(inp.provenance)
+    out["provenance"] = prov
+    old_v = str(out.get("version", "1.0.0")).split(".")
+    try:
+        old_v[1] = str(int(old_v[1]) + 1)
+    except Exception:
+        pass
+    out["version"] = ".".join(old_v)
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:enrich",
+            op="add_edge",
+            value={
+                "id": f"ann:component_enrich:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "enrich_component_metadata", "component_json": out},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+

--- a/backend/tools/datasheets.py
+++ b/backend/tools/datasheets.py
@@ -1,0 +1,26 @@
+"""Datasheet ingestion utilities."""
+from __future__ import annotations
+
+from backend.odl.schemas import PatchOp
+from .schemas import IngestComponentJsonInput, make_patch
+
+
+def ingest_component_json(inp: IngestComponentJsonInput):
+    canon = {}
+    for k, v in inp.raw.items():
+        canon[inp.mapping.get(k, k)] = v
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:ingest",
+            op="add_edge",
+            value={
+                "id": f"ann:ingest:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "ingest_component_json", "component_json": canon},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+

--- a/backend/tools/electrical.py
+++ b/backend/tools/electrical.py
@@ -1,0 +1,320 @@
+"""Electrical design tools.
+
+Pure functions for PV stringing, protective device selection, conductor sizing
+and connection expansion.  Each tool accepts typed input and returns an
+ODLPatch with annotation edges describing the decision for auditability.
+"""
+from __future__ import annotations
+
+from math import log10
+from typing import List
+
+from backend.odl.schemas import PatchOp
+from .schemas import (
+    SelectDcStringingInput,
+    SelectOcpDcInput,
+    SelectOcpAcInput,
+    SelectConductorsInput,
+    ExpandConnectionsInput,
+    BreakerSpec,
+    ConductorChoice,
+    make_patch,
+)
+
+
+# ---------- helpers ----------
+
+def _worst_case_voc(module, env, ref_C: float = 25.0) -> float:
+    dv_pct = module.beta_voc_pct_per_C * (env.ambient_min_C - ref_C)
+    return module.voc_stc * (1.0 + dv_pct / 100.0)
+
+
+def _loglog_interp(points, x: float) -> float:
+    pts = sorted(points, key=lambda p: p[0])
+    if x <= pts[0][0]:
+        return pts[0][1]
+    if x >= pts[-1][0]:
+        return pts[-1][1]
+    for (x1, y1), (x2, y2) in zip(pts, pts[1:]):
+        if x1 <= x <= x2:
+            from math import log10
+
+            lx1, lx2 = log10(x1), log10(x2)
+            ly1, ly2 = log10(y1), log10(y2)
+            t = (log10(x) - lx1) / (lx2 - lx1)
+            ly = ly1 + t * (ly2 - ly1)
+            return 10 ** ly
+    return pts[-1][1]
+
+
+def _vdrop_dc(I: float, ohm_km: float, L_m: float) -> float:
+    return I * ohm_km * (2 * L_m / 1000)
+
+
+def _vdrop_ac_1ph(I: float, ohm_km: float, L_m: float) -> float:
+    return 2 * I * ohm_km * (L_m / 1000)
+
+
+def _vdrop_ac_3ph(I: float, ohm_km: float, L_m: float) -> float:
+    from math import sqrt
+
+    return sqrt(3) * I * ohm_km * (L_m / 1000)
+
+
+# ---------- tools ----------
+
+def select_dc_stringing(inp: SelectDcStringingInput):
+    """Determine safe PV string size and create a symbolic DC connection."""
+
+    voc_worst = _worst_case_voc(inp.module, inp.env)
+    window = inp.inverter.dc_windows[0] if inp.inverter.dc_windows else None
+    max_series = int((inp.inverter.max_system_vdc * inp.series_margin_pct) // voc_worst)
+    vmp_target = inp.module.vmp
+    if window:
+        series = max(1, min(max_series, int(window.v_max // vmp_target)))
+    else:
+        series = max(1, max_series)
+    strings = max(1, min(inp.parallel_limit, inp.desired_module_count // series))
+    mppt_count = window.mppt_count if window else 1
+    strings_per_mppt = [strings // mppt_count] * mppt_count
+    for i in range(strings % mppt_count):
+        strings_per_mppt[i] += 1
+
+    decision = {
+        "series_per_string": series,
+        "parallel_strings": strings,
+        "strings_per_mppt": strings_per_mppt,
+        "voc_worst": voc_worst * series,
+        "vmp_string": inp.module.vmp * series,
+    }
+
+    ops: List[PatchOp] = []
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:dc_stringing",
+            op="add_edge",
+            value={
+                "id": f"ann:dc_stringing:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "select_dc_stringing", "decision": decision},
+            },
+        )
+    )
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:edge:dc_bus",
+            op="add_edge",
+            value={
+                "id": f"dc_bus:{inp.request_id}",
+                "source_id": "inverter_1",
+                "target_id": "pv_array_1",
+                "kind": "electrical",
+                "attrs": {
+                    "dc": True,
+                    "series": series,
+                    "parallel": strings,
+                    "conductors": [
+                        {"function": "PV+", "count": 1},
+                        {"function": "PV-", "count": 1},
+                        {"function": "EGC", "count": 1},
+                    ],
+                },
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+
+
+def select_ocp_dc(inp: SelectOcpDcInput):
+    I_cont = inp.isc_stc_per_string * inp.cont_factor
+    size = next((s for s in sorted(inp.fuse_catalog_A) if s >= I_cont), max(inp.fuse_catalog_A))
+    fuse_required = inp.n_parallel_strings > inp.require_fusing_if_parallel_gt
+    decision = {
+        "fuse_required": fuse_required,
+        "recommended_A": size,
+        "calc_continuous_A": I_cont,
+    }
+    ops: List[PatchOp] = []
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:ocpdc",
+            op="add_edge",
+            value={
+                "id": f"ann:ocp_dc:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "select_ocp_dc", "decision": decision},
+            },
+        )
+    )
+    if fuse_required:
+        ops.append(
+            PatchOp(
+                op_id=f"{inp.request_id}:edge:fuses",
+                op="add_edge",
+                value={
+                    "id": f"fuses:{inp.request_id}",
+                    "source_id": "pv_array_1",
+                    "target_id": "combiner_1",
+                    "kind": "protection",
+                    "attrs": {"device": "fuse", "rating_A": size, "qty": inp.n_parallel_strings},
+                },
+            )
+        )
+    return make_patch(inp.request_id, ops)
+
+
+def select_ocp_ac(inp: SelectOcpAcInput):
+    I_nom = float(inp.inverter.ac_inom_A or 0.0)
+    I_cont = I_nom * inp.cont_factor
+    candidates = [b for b in inp.breaker_library if b.rating_A >= I_cont and b.series_sc_rating_ka >= inp.min_sc_rating_ka]
+    if candidates:
+        b = min(candidates, key=lambda x: x.rating_A)
+        ok = True
+    else:
+        b = max(inp.breaker_library, key=lambda x: x.rating_A)
+        ok = b.series_sc_rating_ka >= inp.min_sc_rating_ka
+    decision = {
+        "breaker_rating_A": b.rating_A,
+        "frame_A": b.frame_A,
+        "poles": b.poles,
+        "curve_points": b.curve.points,
+        "satisfies_sc_rating": ok,
+        "thermal_cont_ok": b.rating_A >= I_cont,
+    }
+    ops: List[PatchOp] = []
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:ocpac",
+            op="add_edge",
+            value={
+                "id": f"ann:ocp_ac:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "select_ocp_ac", "decision": decision},
+            },
+        )
+    )
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:edge:breaker",
+            op="add_edge",
+            value={
+                "id": f"ac_breaker:{inp.request_id}",
+                "source_id": "inverter_1",
+                "target_id": "ac_bus_1",
+                "kind": "protection",
+                "attrs": {"device": "breaker", "rating_A": b.rating_A, "poles": b.poles},
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+
+
+def select_conductors(inp: SelectConductorsInput):
+    I = inp.current_A
+    L = inp.env.length_m
+    target_v = inp.system_v * inp.env.max_vdrop_pct / 100.0
+
+    def vdrop_for(size_label: str) -> float:
+        ohm_km_map = {
+            "14AWG": 8.286,
+            "12AWG": 5.211,
+            "10AWG": 3.277,
+            "8AWG": 2.061,
+            "6AWG": 1.296,
+            "4AWG": 0.815,
+            "2AWG": 0.513,
+            "1/0": 0.324,
+            "2/0": 0.257,
+            "3/0": 0.204,
+            "4/0": 0.162,
+        }
+        ohm_km = ohm_km_map[size_label] * (
+            inp.resistivity_ohm_km[inp.env.material] / 0.018
+        )
+        if inp.phase == "dc":
+            return _vdrop_dc(I, ohm_km, L)
+        if inp.phase == "1ph":
+            return _vdrop_ac_1ph(I, ohm_km, L)
+        return _vdrop_ac_3ph(I, ohm_km, L)
+
+    candidates: List[ConductorChoice] = []
+    for size, base_amp in inp.ampacity_table_A.items():
+        amp = base_amp * inp.derate_ambient_pct * inp.derate_bundling_pct
+        vd = vdrop_for(size)
+        candidates.append(
+            ConductorChoice(
+                size_awg_or_kcmil=size,
+                vdrop_pct=vd / inp.system_v * 100.0,
+                ampacity_A=amp,
+            )
+        )
+    acceptable = [c for c in candidates if c.ampacity_A >= I and c.vdrop_pct <= inp.env.max_vdrop_pct]
+    choice = acceptable[0] if acceptable else max(candidates, key=lambda c: c.ampacity_A)
+    decision = {"choice": choice.model_dump(), "candidates": [c.model_dump() for c in acceptable[:3]]}
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:conductors",
+            op="add_edge",
+            value={
+                "id": f"ann:conductors:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "select_conductors", "decision": decision},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+
+
+def expand_connections(inp: ExpandConnectionsInput):
+    if inp.connection_type == "dc_pv":
+        funcs = ["PV+", "PV-"]
+        if inp.add_ground:
+            funcs.append("EGC")
+    elif inp.connection_type == "ac_3ph_4w":
+        funcs = ["L1", "L2", "L3", "N"]
+        if inp.add_ground:
+            funcs.append("PE")
+    elif inp.connection_type == "ac_1ph_2w":
+        funcs = ["L", "N"]
+        if inp.add_ground:
+            funcs.append("PE")
+    else:
+        funcs = ["A", "B"]
+    ops: List[PatchOp] = []
+    for idx, f in enumerate(funcs):
+        ops.append(
+            PatchOp(
+                op_id=f"{inp.request_id}:edge:{idx}",
+                op="add_edge",
+                value={
+                    "id": f"{inp.source_id}:{f}->{inp.target_id}:{f}:{inp.connection_type}",
+                    "source_id": inp.source_id,
+                    "target_id": inp.target_id,
+                    "kind": "electrical",
+                    "attrs": {"function": f, "count": 1},
+                },
+            )
+        )
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:expand",
+            op="add_edge",
+            value={
+                "id": f"ann:expand:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "expand_connections", "functions": funcs},
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+

--- a/backend/tools/schemas.py
+++ b/backend/tools/schemas.py
@@ -120,3 +120,192 @@ def make_patch(request_id: str, ops: List[PatchOp]) -> ODLPatch:
     """Create an ODLPatch with a deterministic patch_id from request_id."""
 
     return ODLPatch(patch_id=f"patch:{request_id}", operations=ops)
+
+
+# ---------- Electrical & Analysis ----------
+
+
+class EnvProfile(BaseModel):
+    """Site environment bounds for electrical calculations."""
+
+    ambient_min_C: float = Field(..., description="Lowest ambient temperature")
+    ambient_max_C: float = Field(..., description="Highest ambient temperature")
+    elevation_m: float | None = Field(
+        None, description="Site elevation for optional corrections"
+    )
+
+
+class PvModuleSpec(BaseModel):
+    """Minimal PV module electrical specification."""
+
+    voc_stc: float
+    isc_stc: float
+    vmp: float
+    imp: float
+    beta_voc_pct_per_C: float = Field(
+        ..., description="Voc temperature coefficient (%/°C, negative)"
+    )
+
+
+class InverterDcWindow(BaseModel):
+    v_min: float
+    v_max: float
+    mppt_count: int = 1
+
+
+class InverterSpec(BaseModel):
+    """Inverter side parameters required for stringing/OCPD."""
+
+    dc_windows: List[InverterDcWindow] = Field(default_factory=list)
+    max_system_vdc: float = 1000.0
+    ac_v_ll: float | None = None
+    ac_phase: Literal["1", "3"] = "3"
+    ac_freq_hz: int = 50
+    ac_inom_A: float | None = None
+    ifault_multiplier: float = Field(1.2, description="Fault current multiple")
+
+
+class BreakerCurve(BaseModel):
+    """Time–current characteristic as list of (multiple, seconds)."""
+
+    points: List[tuple[float, float]]
+
+
+class BreakerSpec(BaseModel):
+    rating_A: int
+    frame_A: int
+    curve: BreakerCurve
+    voltage: float
+    poles: int
+    series_sc_rating_ka: float
+
+
+class ConductorEnv(BaseModel):
+    material: Literal["Cu", "Al"] = "Cu"
+    insulation: Literal["THHN", "XHHW", "PVC", "XLPE"] = "THHN"
+    installation: Literal["conduit", "tray", "free_air"] = "conduit"
+    current_carrying: int = Field(
+        2, description="Number of current-carrying conductors in the raceway"
+    )
+    length_m: float = 10.0
+    max_vdrop_pct: float = 3.0
+
+
+class ConductorChoice(BaseModel):
+    size_awg_or_kcmil: str
+    qty_per_phase: int = 1
+    vdrop_pct: float
+    ampacity_A: float
+
+
+# ---------- Tool inputs ----------
+
+
+class SelectDcStringingInput(ToolBase):
+    view_nodes: List[ODLNode] = Field(default_factory=list)
+    module: PvModuleSpec
+    inverter: InverterSpec
+    env: EnvProfile
+    desired_module_count: int
+    parallel_limit: int = 12
+    series_margin_pct: float = 0.97
+
+
+class SelectOcpDcInput(ToolBase):
+    view_nodes: List[ODLNode] = Field(default_factory=list)
+    isc_stc_per_string: float
+    n_parallel_strings: int
+    cont_factor: float = 1.25
+    fuse_catalog_A: List[int] = Field(default_factory=lambda: [10, 15, 20, 25, 30])
+    require_fusing_if_parallel_gt: int = 2
+
+
+class SelectOcpAcInput(ToolBase):
+    view_nodes: List[ODLNode] = Field(default_factory=list)
+    inverter: InverterSpec
+    breaker_library: List[BreakerSpec]
+    cont_factor: float = 1.25
+    min_sc_rating_ka: float = 10.0
+
+
+class ApplyBreakerCurveInput(ToolBase):
+    breaker_curve: BreakerCurve
+    current_multiple: float
+
+
+class SelectConductorsInput(ToolBase):
+    view_nodes: List[ODLNode] = Field(default_factory=list)
+    current_A: float
+    system_v: float
+    phase: Literal["dc", "1ph", "3ph"] = "dc"
+    env: ConductorEnv
+    resistivity_ohm_km: Dict[str, float] = Field(
+        default_factory=lambda: {"Cu": 0.018, "Al": 0.029}
+    )
+    ampacity_table_A: Dict[str, float] = Field(
+        default_factory=lambda: {
+            "14AWG": 20,
+            "12AWG": 25,
+            "10AWG": 35,
+            "8AWG": 50,
+            "6AWG": 65,
+            "4AWG": 85,
+            "2AWG": 115,
+            "1/0": 150,
+            "2/0": 175,
+            "3/0": 200,
+            "4/0": 230,
+        }
+    )
+    derate_ambient_pct: float = 1.0
+    derate_bundling_pct: float = 1.0
+
+
+class CalcVdropInput(ToolBase):
+    current_A: float
+    system_v: float
+    phase: Literal["dc", "1ph", "3ph"]
+    R_ohm_per_km: float
+    length_m: float
+
+
+class CalcIfaultInput(ToolBase):
+    dc_isc_stc: float | None = None
+    dc_parallel_strings: int | None = None
+    dc_multiplier: float = 1.25
+    ac_inverter_inom: float | None = None
+    ac_fault_multiple: float = 1.2
+
+
+class ExpandConnectionsInput(ToolBase):
+    source_id: str
+    target_id: str
+    connection_type: Literal["dc_pv", "ac_3ph_4w", "ac_1ph_2w", "rs485"] = "dc_pv"
+    add_ground: bool = True
+
+
+class CheckComplianceInput(ToolBase):
+    env: EnvProfile
+    module: PvModuleSpec | None = None
+    inverter: InverterSpec | None = None
+    dc_series_count: int | None = None
+    profile: Literal["NEC_2023", "IEC_60364", "AS_NZS_3000"] = "NEC_2023"
+
+
+class EnrichComponentMetadataInput(ToolBase):
+    existing_json: Dict[str, object] = Field(default_factory=dict)
+    new_attrs: Dict[str, object] = Field(default_factory=dict)
+    provenance: Dict[str, str] = Field(default_factory=dict)
+
+
+class IngestComponentJsonInput(ToolBase):
+    raw: Dict[str, object]
+    mapping: Dict[str, str] = Field(default_factory=dict)
+
+
+class LinkBudgetPlannerInput(ToolBase):
+    topology: Literal["rs485_multi_drop", "ethernet_star"] = "rs485_multi_drop"
+    device_count: int
+    segment_length_m: float
+    baud: int = 9600
+

--- a/backend/tools/standards.py
+++ b/backend/tools/standards.py
@@ -1,0 +1,35 @@
+"""Compliance checks against electrical standards."""
+from __future__ import annotations
+
+from backend.odl.schemas import PatchOp
+from .schemas import CheckComplianceInput, make_patch
+from .electrical import _worst_case_voc
+
+
+def check_compliance(inp: CheckComplianceInput):
+    findings = []
+    if inp.module and inp.dc_series_count and inp.inverter:
+        voc_worst = _worst_case_voc(inp.module, inp.env) * inp.dc_series_count
+        if voc_worst > inp.inverter.max_system_vdc:
+            findings.append(
+                {
+                    "code": "DC_MAX_V",
+                    "severity": "error",
+                    "message": f"String Voc {voc_worst:.1f} V exceeds limit {inp.inverter.max_system_vdc} V",
+                }
+            )
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:compliance",
+            op="add_edge",
+            value={
+                "id": f"ann:compliance:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "check_compliance", "result": {"findings": findings}},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+

--- a/tests/test_originflow_tools.py
+++ b/tests/test_originflow_tools.py
@@ -1,0 +1,151 @@
+import math
+import pathlib
+import importlib.util
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+# Stub backend.odl.schemas to avoid heavy dependencies during tests
+import types
+
+schemas_spec = importlib.util.spec_from_file_location(
+    "backend.odl.schemas", ROOT / "backend/odl/schemas.py"
+)
+schemas_module = importlib.util.module_from_spec(schemas_spec)
+schemas_spec.loader.exec_module(schemas_module)  # type: ignore
+sys.modules.setdefault("backend", types.ModuleType("backend"))
+backend_odl = types.ModuleType("backend.odl")
+backend_odl.schemas = schemas_module  # type: ignore
+sys.modules["backend.odl"] = backend_odl
+sys.modules["backend.odl.schemas"] = schemas_module
+backend_tools = types.ModuleType("backend.tools")
+backend_tools.__path__ = [str(ROOT / "backend" / "tools")]
+sys.modules.setdefault("backend.tools", backend_tools)
+
+def _load(mod: str):
+    path = ROOT / "backend" / "tools" / f"{mod}.py"
+    name = f"backend.tools.{mod}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+electrical = _load("electrical")
+analysis = _load("analysis")
+standards = _load("standards")
+components = _load("components")
+datasheets = _load("datasheets")
+comm = _load("comm")
+
+from backend.tools.schemas import (
+    SelectDcStringingInput,
+    PvModuleSpec,
+    InverterSpec,
+    InverterDcWindow,
+    EnvProfile,
+    SelectOcpDcInput,
+    SelectOcpAcInput,
+    BreakerCurve,
+    BreakerSpec,
+    ApplyBreakerCurveInput,
+    SelectConductorsInput,
+    ConductorEnv,
+    CalcVdropInput,
+    CalcIfaultInput,
+    ExpandConnectionsInput,
+    CheckComplianceInput,
+    EnrichComponentMetadataInput,
+    IngestComponentJsonInput,
+    LinkBudgetPlannerInput,
+)
+
+
+SESSION = "s"
+
+
+def test_dc_stringing_basic():
+    inp = SelectDcStringingInput(
+        session_id=SESSION,
+        request_id="r1",
+        module=PvModuleSpec(voc_stc=40, isc_stc=10, vmp=32, imp=9, beta_voc_pct_per_C=-0.28),
+        inverter=InverterSpec(dc_windows=[InverterDcWindow(v_min=200, v_max=800, mppt_count=2)], max_system_vdc=600),
+        env=EnvProfile(ambient_min_C=-10, ambient_max_C=50),
+        desired_module_count=20,
+    )
+    patch = electrical.select_dc_stringing(inp)
+    assert any(op.value["id"].startswith("ann:dc_stringing") for op in patch.operations)
+
+
+def test_ocp_dc():
+    inp = SelectOcpDcInput(session_id=SESSION, request_id="r2", isc_stc_per_string=10, n_parallel_strings=4)
+    patch = electrical.select_ocp_dc(inp)
+    ann = [op for op in patch.operations if op.value["id"].startswith("ann:ocp_dc")][0]
+    assert ann.value["attrs"]["decision"]["fuse_required"] is True
+
+
+def test_ocp_ac():
+    curve = BreakerCurve(points=[(3, 100), (5, 10), (10, 0.5)])
+    lib = [BreakerSpec(rating_A=25, frame_A=25, curve=curve, voltage=480, poles=2, series_sc_rating_ka=22)]
+    inv = InverterSpec(dc_windows=[], max_system_vdc=600, ac_inom_A=20)
+    inp = SelectOcpAcInput(session_id=SESSION, request_id="r3", inverter=inv, breaker_library=lib)
+    patch = electrical.select_ocp_ac(inp)
+    assert any(op.value["id"].startswith("ac_breaker") for op in patch.operations)
+
+
+def test_breaker_curve():
+    curve = BreakerCurve(points=[(3, 100), (5, 10), (10, 0.5)])
+    inp = ApplyBreakerCurveInput(session_id=SESSION, request_id="r4", breaker_curve=curve, current_multiple=5)
+    patch = analysis.apply_breaker_curve(inp)
+    val = patch.operations[0].value["attrs"]["result"]["t_trip_s"]
+    assert 1 < val < 20
+
+
+def test_conductor_selection_and_vdrop():
+    env = ConductorEnv(length_m=30, max_vdrop_pct=3)
+    inp = SelectConductorsInput(session_id=SESSION, request_id="r5", current_A=20, system_v=480, env=env)
+    patch = electrical.select_conductors(inp)
+    ann = patch.operations[0].value["attrs"]["decision"]["choice"]
+    assert float(ann["ampacity_A"]) >= 20
+    vd_inp = CalcVdropInput(session_id=SESSION, request_id="r6", current_A=20, system_v=480, phase="3ph", R_ohm_per_km=0.2, length_m=30)
+    vpatch = analysis.calculate_voltage_drop(vd_inp)
+    assert vpatch.operations[0].value["attrs"]["result"]["v_drop_V"] > 0
+
+
+def test_fault_current():
+    inp = CalcIfaultInput(session_id=SESSION, request_id="r7", dc_isc_stc=10, dc_parallel_strings=3, ac_inverter_inom=20)
+    patch = analysis.calculate_fault_current(inp)
+    attrs = patch.operations[0].value["attrs"]["result"]
+    assert attrs["dc_fault_A"] == 37.5
+    assert attrs["ac_fault_A"] == 24.0
+
+
+def test_expand_and_compliance():
+    epatch = electrical.expand_connections(ExpandConnectionsInput(session_id=SESSION, request_id="r8", source_id="a", target_id="b"))
+    assert len(epatch.operations) >= 3
+    cpatch = standards.check_compliance(
+        CheckComplianceInput(
+            session_id=SESSION,
+            request_id="r9",
+            env=EnvProfile(ambient_min_C=-10, ambient_max_C=50),
+            module=PvModuleSpec(voc_stc=40, isc_stc=10, vmp=32, imp=9, beta_voc_pct_per_C=-0.28),
+            inverter=InverterSpec(dc_windows=[], max_system_vdc=1000),
+            dc_series_count=30,
+        )
+    )
+    assert cpatch.operations[0].value["attrs"]["result"]["findings"]
+
+
+def test_components_datasheets_comm():
+    enrich = components.enrich_component_metadata(
+        EnrichComponentMetadataInput(session_id=SESSION, request_id="r10", existing_json={"id": "x"}, new_attrs={"a": 1}, provenance={"src": "test"})
+    )
+    assert enrich.operations[0].value["attrs"]["component_json"]["a"] == 1
+    ingest = datasheets.ingest_component_json(
+        IngestComponentJsonInput(session_id=SESSION, request_id="r11", raw={"Voc": 50}, mapping={"Voc": "voc_stc"})
+    )
+    assert ingest.operations[0].value["attrs"]["component_json"]["voc_stc"] == 50
+    link = comm.link_budget_planner(LinkBudgetPlannerInput(session_id=SESSION, request_id="r12", topology="rs485_multi_drop", device_count=5, segment_length_m=1500))
+    assert link.operations[0].value["attrs"]["ok"] is False
+


### PR DESCRIPTION
## Summary
- extend tool schemas with environment, component, and protection models
- implement electrical/analysis/standards/component tools for stringing, OCPD, conductor sizing, and compliance
- add unit tests covering end-to-end decisions

## Testing
- `pytest tests/test_originflow_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab36e48dd48329bdfcded4ad5e4a53