### PR TITLE
docs: replace vNext with OriginFlow

### DIFF
--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -1,6 +1,6 @@
-# API Contracts (vNext)
+# API Contracts (OriginFlow)
 
-This document captures the **current** API surface. Backward compatibility with legacy envelopes/endpoints is intentionally **not** maintained.
+This document captures the **current** OriginFlow API surface. Backward compatibility with legacy envelopes/endpoints is intentionally **not** maintained.
 
 ## Response envelope (ADPF)
 ```json

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,6 +1,6 @@
-# Architecture Overview (vNext)
+# Architecture Overview (OriginFlow)
 
-This document summarizes the **clean, modern agentic architecture** shipped in Phases 1–9. The codebase favors **one LLM-backed orchestrator**, a **typed tool catalog**, and a **state-aware ODL model** as the single source of truth.
+This document summarizes the **clean, modern agentic architecture** of OriginFlow shipped in Phases 1–9. The codebase favors **one LLM-backed orchestrator**, a **typed tool catalog**, and a **state-aware ODL model** as the single source of truth.
 
 ## Big picture
 ```text

--- a/docs/BREAKING_CHANGES.md
+++ b/docs/BREAKING_CHANGES.md
@@ -1,6 +1,6 @@
-# BREAKING CHANGES (vNext)
+# BREAKING CHANGES (OriginFlow)
 
-This release intentionally **removes backward compatibility** to achieve a
+This OriginFlow release intentionally **removes backward compatibility** to achieve a
 cleaner, simpler, and more robust agentic architecture.
 
 ## Summary


### PR DESCRIPTION
## Summary
- update key docs to reference OriginFlow instead of vNext
- refresh introductory sentences to mention OriginFlow explicitly

## Testing
- `pre-commit run --files docs/ARCHITECTURE_OVERVIEW.md docs/BREAKING_CHANGES.md docs/API_CONTRACTS.md` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7df79ba083299fb0dff13c8ca0e8