### PR TITLE
docs: update planner comment to OriginFlow flow

### DIFF
--- a/backend/api/routes/odl_plan.py
+++ b/backend/api/routes/odl_plan.py
@@ -5,7 +5,7 @@ Exposes:
   GET /api/v1/odl/sessions/{session_id}/plan?command=...
 
 Returns an AiPlan containing a small set of deterministic tasks that the
-frontend can execute via /odl/sessions/{sid}/act (vNext flow). The planner
+frontend can execute via /odl/sessions/{sid}/act (OriginFlow flow). The planner
 is intentionally rule-based for MVP reliability; it parses key quantities
 from natural language (e.g., "design a 5kW ...") and emits typed tasks.
 """


### PR DESCRIPTION
## Summary
- rename ODL planner docstring reference from vNext to OriginFlow flow

## Testing
- `pre-commit run --files backend/api/routes/odl_plan.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7df266bc832983481d26341a0db2