### PR TITLE
Introduce auto design pipeline with equipment selection and BOM

### DIFF
--- a/backend/orchestrator/auto_designer.py
+++ b/backend/orchestrator/auto_designer.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+from typing import List, Dict, Any
+from backend.tools.schemas import make_patch
+from backend.odl.schemas import PatchOp, ODLPatch
+from backend.orchestrator.plan_spec import PlanSpec
+from backend.tools import design_state, standards_check_v2, electrical_v2
+from backend.tools import select_equipment, stringing, ocp_dc, materialize, schedules as schedules_tool
+from backend.tools import routing, mechanical, labels as labels_tool, bom as bom_tool, explain_design_v2
+
+
+def _collect_ops(*patches: ODLPatch | Dict[str, Any]) -> List[PatchOp]:
+    ops: List[PatchOp] = []
+    for p in patches:
+        if not p:
+            continue
+        if isinstance(p, dict):
+            ops.extend(p.get("ops", []))
+        else:
+            ops.extend(getattr(p, "operations", []))
+    return ops
+
+
+def run_auto_design(spec: PlanSpec, session_id: str, request_id: str, simulate: bool = True) -> ODLPatch:
+    """End-to-end planner. Returns an ODLPatch (not applied) that the UI can preview."""
+    ops: List[PatchOp] = []
+    # 1) design state
+    ds_patch = design_state.compute_design_state(
+        design_state.ComputeDesignStateInput(
+            session_id=session_id,
+            request_id=f"{request_id}:ds",
+            env=design_state.Env(
+                site_tmin_C=spec.env.site_tmin_C,
+                site_tmax_C=spec.env.site_tmax_C,
+                code_profile=spec.env.profile,
+            ),
+            modules=[],
+            inverters=[],
+            view_nodes=[],
+        )
+    )
+    ops += _collect_ops(ds_patch)
+
+    # 2) equipment
+    eq_patch = select_equipment.select_equipment(
+        select_equipment.SelectEquipmentInput(
+            session_id=session_id,
+            request_id=f"{request_id}:equip",
+            target_kw_stc=spec.targets.dc_kw_stc,
+        )
+    )
+    ops += _collect_ops(eq_patch)
+
+    # 3) stringing (use catalog first item for simplicity)
+    from backend.tools.catalog import load_modules, load_inverters
+
+    m = load_modules()[0]
+    inv = load_inverters()[0]
+    str_patch = stringing.select_dc_stringing(
+        stringing.SelectStringingInput(
+            session_id=session_id,
+            request_id=f"{request_id}:string",
+            target_kw_stc=spec.targets.dc_kw_stc,
+            env=stringing.Env(site_tmin_C=spec.env.site_tmin_C),
+            module=stringing.Module(
+                p_W=m.p_W,
+                voc=m.voc,
+                vmp=m.vmp,
+                imp=m.imp,
+                beta_voc_pct_per_C=m.beta_voc_pct_per_C,
+            ),
+            inverter=stringing.Inverter(
+                max_system_vdc=inv.max_system_vdc,
+                mppt_windows=[stringing.MpptWindow(**w) for w in inv.mppt_windows],
+            ),
+        )
+    )
+    ops += _collect_ops(str_patch)
+
+    # 4) fast compliance check (gate)
+    from backend.tools.standards_check_v2 import (
+        CheckComplianceV2Input,
+        Env as CEnv,
+        Module as CMod,
+        Inverter as CInv,
+        MPPT,
+    )
+
+    comp = standards_check_v2.check_compliance_v2(
+        CheckComplianceV2Input(
+            session_id=session_id,
+            request_id=f"{request_id}:cc0",
+            env=CEnv(
+                site_tmin_C=spec.env.site_tmin_C,
+                site_tmax_C=spec.env.site_tmax_C,
+                code_profile=spec.env.profile,
+            ),
+            module=CMod(
+                voc_stc=m.voc,
+                vmp=m.vmp,
+                isc_stc=m.isc,
+                beta_voc_pct_per_C=m.beta_voc_pct_per_C,
+            ),
+            inverter=CInv(
+                max_system_vdc=inv.max_system_vdc,
+                mppt=MPPT(
+                    v_min=inv.mppt_windows[0]["v_min"],
+                    v_max=inv.mppt_windows[0]["v_max"],
+                    count=inv.mppt_windows[0].get("count", 1),
+                ),
+            ),
+            dc_series_count=7,
+        )
+    )
+    ops += _collect_ops(comp)
+
+    # 5) DC OCPD determination
+    ocpdc = ocp_dc.select_ocp_dc(
+        ocp_dc.SelectOcpDcInput(
+            session_id=session_id,
+            request_id=f"{request_id}:ocpdc",
+            strings_parallel=2,
+            module=ocp_dc.Module(isc=m.isc),
+        )
+    )
+    ops += _collect_ops(ocpdc)
+
+    # 6) AC OCPD
+    acpd = electrical_v2.select_ocp_ac_v2(
+        electrical_v2.SelectOcpACV2Input(
+            session_id=session_id,
+            request_id=f"{request_id}:ocpac",
+            inverter_inom_A=round((inv.ac_kW * 1000) / 240.0, 2),
+        )
+    )
+    ops += _collect_ops(acpd)
+
+    # 7) Conductors (first pass – nominal lengths)
+    cdc = electrical_v2.select_conductors_v2(
+        electrical_v2.SelectConductorsV2Input(
+            session_id=session_id,
+            request_id=f"{request_id}:cdc",
+            circuit_kind="dc_string",
+            current_A=10.7,
+            length_m=15.0,
+            system_v=290.0,
+        )
+    )
+    cac = electrical_v2.select_conductors_v2(
+        electrical_v2.SelectConductorsV2Input(
+            session_id=session_id,
+            request_id=f"{request_id}:cac",
+            circuit_kind="ac_feeder",
+            current_A=round((inv.ac_kW * 1000) / 240.0, 2),
+            length_m=20.0,
+            system_v=240.0,
+        )
+    )
+    ops += _collect_ops(cdc, cac)
+
+    # 8) Materialize nodes/edges (simulate switch)
+    mats = materialize.materialize_design(
+        materialize.MaterializeDesignInput(
+            session_id=session_id,
+            request_id=f"{request_id}:mat",
+            simulate=simulate,
+            inverter_id=inv.id,
+            inverter_title=inv.title,
+            mppts=sum(w.get("count", 1) for w in inv.mppt_windows),
+            modules=14 if spec.targets.dc_kw_stc >= 5 else 8,
+            modules_per_string=7 if spec.targets.dc_kw_stc >= 5 else 8,
+            strings_parallel=2 if spec.targets.dc_kw_stc >= 5 else 1,
+        )
+    )
+    ops += _collect_ops(mats)
+
+    # 9) Expand connections (bundle edges)
+    exp = electrical_v2.expand_connections_v2(
+        electrical_v2.ExpandConnectionsV2Input(
+            session_id=session_id,
+            request_id=f"{request_id}:expand",
+            source_id="INV1",
+            target_id="MAIN" if not simulate else "MAIN",
+            connection_type="ac_1ph_3w",
+            add_ground=True,
+        )
+    )
+    ops += _collect_ops(exp)
+
+    # 10) Route bundles (compute lengths)
+    routes = routing.plan_routes(
+        routing.PlanRoutesInput(
+            session_id=session_id,
+            request_id=f"{request_id}:route",
+            bundles=[
+                routing.BundleRef(
+                    id="bundle:INV1:MAIN:ac_1ph_3w",
+                    source_id="INV1",
+                    target_id="MAIN",
+                    system="ac_1ph_3w",
+                    attrs={},
+                )
+            ],
+            node_poses={"INV1": routing.Pose(x=0, y=0), "MAIN": routing.Pose(x=10, y=0)},
+            default_length_m=10.0,
+        )
+    )
+    ops += _collect_ops(routes)
+
+    # 11) Mechanical
+    mech = mechanical.layout_racking(
+        mechanical.LayoutRackingInput(
+            session_id=session_id,
+            request_id=f"{request_id}:mech",
+            roof=mechanical.RoofPlane(
+                id="R1",
+                tilt_deg=25,
+                azimuth_deg=180,
+                width_m=11.0,
+                height_m=6.0,
+                setback_m=0.5,
+            ),
+            modules_count=14 if spec.targets.dc_kw_stc >= 5 else 8,
+        )
+    )
+    ops += _collect_ops(mech)
+
+    # 12) Schedules (uses routes)
+    route_data = []
+    for op in routes.operations:
+        if op.op == "set_meta" and op.value.get("path") == "physical.routes":
+            route_data = op.value.get("data", [])
+            break
+    sch = schedules_tool.generate_schedules(
+        schedules_tool.GenerateSchedulesInput(
+            session_id=session_id,
+            request_id=f"{request_id}:sched",
+            view_edges=[],
+            routes=route_data,
+        )
+    )
+    ops += _collect_ops(sch)
+
+    # 13) Labels
+    labs = labels_tool.generate_labels(
+        labels_tool.GenerateLabelsInput(
+            session_id=session_id,
+            request_id=f"{request_id}:labels",
+            view_nodes=[],
+            view_edges=[],
+        )
+    )
+    ops += _collect_ops(labs)
+
+    # 14) Final compliance (lightweight)
+    final = standards_check_v2.check_compliance_v2(
+        CheckComplianceV2Input(
+            session_id=session_id,
+            request_id=f"{request_id}:ccf",
+            env=CEnv(
+                site_tmin_C=spec.env.site_tmin_C,
+                site_tmax_C=spec.env.site_tmax_C,
+                code_profile=spec.env.profile,
+            ),
+            module=CMod(
+                voc_stc=m.voc,
+                vmp=m.vmp,
+                isc_stc=m.isc,
+                beta_voc_pct_per_C=m.beta_voc_pct_per_C,
+            ),
+            inverter=CInv(
+                max_system_vdc=inv.max_system_vdc,
+                mppt=MPPT(
+                    v_min=inv.mppt_windows[0]["v_min"],
+                    v_max=inv.mppt_windows[0]["v_max"],
+                    count=inv.mppt_windows[0].get("count", 1),
+                ),
+            ),
+            dc_series_count=7 if spec.targets.dc_kw_stc >= 5 else 8,
+            ac_conductor=None,
+            dc_ocpd=None,
+            circuit_kind="ac_feeder",
+        )
+    )
+    ops += _collect_ops(final)
+
+    # 15) BOM (pull schedules if any)
+    sched_data = {}
+    for op in sch.operations:
+        if op.op == "set_meta" and op.value.get("path") == "physical.schedules":
+            sched_data = op.value.get("data", {})
+            break
+    bom = bom_tool.generate_bom(
+        bom_tool.GenerateBOMInput(
+            session_id=session_id,
+            request_id=f"{request_id}:bom",
+            bundles=[],
+            schedules=sched_data,
+            equip={
+                "inverter": {"id": inv.id, "title": inv.title},
+                "module": {"id": m.id, "title": m.title},
+                "array_modules": 14 if spec.targets.dc_kw_stc >= 5 else 8,
+            },
+        )
+    )
+    ops += _collect_ops(bom)
+
+    # 16) Story
+    story = explain_design_v2.explain_design_v2(
+        explain_design_v2.ExplainDesignV2Input(
+            session_id=session_id,
+            request_id=f"{request_id}:story",
+            design_state={
+                "env": {
+                    "site_tmin_C": spec.env.site_tmin_C,
+                    "site_tmax_C": spec.env.site_tmax_C,
+                },
+                "counts": {
+                    "modules": 14 if spec.targets.dc_kw_stc >= 5 else 8,
+                    "inverters": 1,
+                },
+            },
+            audience="non-technical",
+        )
+    )
+    ops += _collect_ops(story)
+
+    return make_patch(request_id, ops)
+
+
+__all__ = ["run_auto_design"]
+

--- a/backend/orchestrator/plan_spec.py
+++ b/backend/orchestrator/plan_spec.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+from typing import List, Optional, Dict
+from pydantic import BaseModel, Field
+
+
+class RoofPlane(BaseModel):
+    id: str
+    tilt_deg: float
+    azimuth_deg: float
+    w: float
+    h: float
+    setbacks_m: float = 0.5
+
+
+class Env(BaseModel):
+    site_tmin_C: float = -10.0
+    site_tmax_C: float = 45.0
+    utility: str = "120/240V"
+    profile: str = "NEC_2023"
+
+
+class Targets(BaseModel):
+    dc_kw_stc: float
+    vd_dc_pct: float = 2.0
+    vd_ac_pct: float = 3.0
+
+
+class Constraints(BaseModel):
+    bus_A: int = 200
+    main_A: int = 200
+    interconnection: str = "load_side"
+
+
+class Preferences(BaseModel):
+    optimizer: str = "cost"
+    mlpe: str = "auto"  # "required" | "none" | "auto"
+
+
+class PlanSpec(BaseModel):
+    scope: str = "pv_resi_grid_tied"
+    env: Env
+    targets: Targets
+    constraints: Constraints = Constraints()
+    preferences: Preferences = Preferences()
+    inputs_optional: Dict = Field(default_factory=dict)  # roof, waypoints, etc.
+
+
+__all__ = ["PlanSpec", "Env", "Targets", "Constraints", "Preferences", "RoofPlane"]
+

--- a/backend/tests/test_auto_designer.py
+++ b/backend/tests/test_auto_designer.py
@@ -1,0 +1,21 @@
+from backend.orchestrator.plan_spec import PlanSpec, Env, Targets
+from backend.orchestrator.auto_designer import run_auto_design
+
+
+def test_auto_design_simulates_end_to_end():
+    spec = PlanSpec(env=Env(site_tmin_C=-10, site_tmax_C=45), targets=Targets(dc_kw_stc=3.0))
+    patch = run_auto_design(spec, session_id="s", request_id="ad1", simulate=True)
+    ops = patch.operations
+    # must include annotations and set_meta for schedules/bom
+    assert any(op.op == "set_meta" and op.value.get("path") == "physical.schedules" for op in ops)
+    assert any(op.op == "set_meta" and op.value.get("path") == "physical.bom" for op in ops)
+    assert any(op.op == "add_edge" and op.value["id"].startswith("ann:") for op in ops)
+
+
+def test_auto_design_materializes_nodes():
+    spec = PlanSpec(env=Env(site_tmin_C=-10, site_tmax_C=45), targets=Targets(dc_kw_stc=3.0))
+    patch = run_auto_design(spec, session_id="s", request_id="ad2", simulate=False)
+    ops = patch.operations
+    assert any(op.op == "add_node" and op.value["type"] == "string_inverter" for op in ops)
+    assert sum(1 for op in ops if op.op == "add_node" and op.value["type"] == "pv_module") >= 8
+

--- a/backend/tests/test_selection_and_stringing.py
+++ b/backend/tests/test_selection_and_stringing.py
@@ -1,0 +1,33 @@
+from backend.tools.select_equipment import select_equipment, SelectEquipmentInput
+from backend.tools.stringing import (
+    select_dc_stringing,
+    SelectStringingInput,
+    Env,
+    Module,
+    Inverter,
+    MpptWindow,
+)
+
+
+def test_select_equipment_picks_reasonable_models():
+    patch = select_equipment(SelectEquipmentInput(session_id="s", request_id="r", target_kw_stc=3.0))
+    ops = patch.operations
+    assert any(op.op == "set_meta" and op.value.get("path") == "design_state.equip" for op in ops)
+
+
+def test_stringing_respects_voltage_and_mppt():
+    m = Module(p_W=400, voc=49.5, vmp=41.5, imp=10.7, beta_voc_pct_per_C=-0.28)
+    inv = Inverter(max_system_vdc=600, mppt_windows=[MpptWindow(v_min=200, v_max=550, count=2)])
+    patch = select_dc_stringing(
+        SelectStringingInput(
+            session_id="s",
+            request_id="r2",
+            target_kw_stc=5.0,
+            env=Env(site_tmin_C=-10),
+            module=m,
+            inverter=inv,
+        )
+    )
+    ann = [op for op in patch.operations if op.op == "add_edge"][0]
+    assert "N=" in ann.value["attrs"]["summary"]
+

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -17,6 +17,7 @@ from . import (
     replacement,
     deletion,
     electrical,
+    electrical_v2,
     analysis,
     standards,
     components,
@@ -30,6 +31,12 @@ from . import (
     routing,
     mechanical,
     labels,
+    select_equipment,
+    stringing,
+    ocp_dc,
+    materialize,
+    bom,
+    catalog,
 )
 
 __all__ = [
@@ -43,6 +50,7 @@ __all__ = [
     "replacement",
     "deletion",
     "electrical",
+    "electrical_v2",
     "analysis",
     "standards",
     "components",
@@ -56,4 +64,10 @@ __all__ = [
     "routing",
     "mechanical",
     "labels",
+    "select_equipment",
+    "stringing",
+    "ocp_dc",
+    "materialize",
+    "bom",
+    "catalog",
 ]

--- a/backend/tools/bom.py
+++ b/backend/tools/bom.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+from typing import List, Dict
+from pydantic import BaseModel, Field
+from backend.odl.schemas import PatchOp
+from backend.tools.schemas import ToolBase, ODLEdge, make_patch
+
+
+class GenerateBOMInput(ToolBase):
+    bundles: List[ODLEdge] = Field(default_factory=list)
+    schedules: Dict = Field(default_factory=dict)
+    equip: Dict = Field(default_factory=dict)
+
+
+def generate_bom(inp: GenerateBOMInput):
+    items = []
+    # Equip
+    if "module" in inp.equip:
+        items.append({
+            "sku": inp.equip["module"]["id"],
+            "title": inp.equip["module"]["title"],
+            "qty": inp.equip.get("array_modules", 0) or 0,
+        })
+    if "inverter" in inp.equip:
+        items.append({
+            "sku": inp.equip["inverter"]["id"],
+            "title": inp.equip["inverter"]["title"],
+            "qty": 1,
+        })
+    # Cables from schedules
+    for row in inp.schedules.get("cables", []):
+        items.append({
+            "sku": "CABLE",
+            "title": f"{row['system']} cable bundle",
+            "qty": 1,
+            "length_m": row.get("length_m", 0.0),
+        })
+    # Raceways
+    for row in inp.schedules.get("raceways", []):
+        items.append({
+            "sku": "RACEWAY",
+            "title": row["type"],
+            "qty": 1,
+            "length_m": row.get("length_m", 0.0),
+        })
+    # Terminations
+    for row in inp.schedules.get("terminations", []):
+        items.append({
+            "sku": "LUGS/GLANDS",
+            "title": "Terminations",
+            "qty": row.get("lugs", 0) + row.get("glands", 0),
+        })
+    ops: List[PatchOp] = []
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:meta:bom",
+            op="set_meta",
+            value={"path": "physical.bom", "merge": True, "data": items},
+        )
+    )
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:bom",
+            op="add_edge",
+            value={
+                "id": f"ann:bom:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "generate_bom", "summary": f"{len(items)} BOM lines"},
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+
+
+__all__ = ["GenerateBOMInput", "generate_bom"]
+

--- a/backend/tools/catalog.py
+++ b/backend/tools/catalog.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Any
+
+
+CAT_DIR = Path(__file__).parent / "data" / "catalog"
+
+
+@dataclass
+class ModuleItem:
+    id: str
+    title: str
+    p_W: float
+    voc: float
+    vmp: float
+    isc: float
+    imp: float
+    beta_voc_pct_per_C: float
+
+
+@dataclass
+class InverterItem:
+    id: str
+    title: str
+    ac_kW: float
+    ac_V: str
+    phases: str
+    max_system_vdc: float
+    mppt_windows: List[Dict[str, float]]
+
+
+def _load(path: Path) -> List[Dict[str, Any]]:
+    return json.loads(path.read_text())
+
+
+def load_modules() -> List[ModuleItem]:
+    return [ModuleItem(**x) for x in _load(CAT_DIR / "modules.json")]
+
+
+def load_inverters() -> List[InverterItem]:
+    return [InverterItem(**x) for x in _load(CAT_DIR / "inverters.json")]
+
+
+__all__ = ["ModuleItem", "InverterItem", "load_modules", "load_inverters"]
+

--- a/backend/tools/data/catalog/inverters.json
+++ b/backend/tools/data/catalog/inverters.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "INV_5K_2MPPT_600V",
+    "title": "String inverter 5 kW 240V, 2 MPPT, 600Vdc",
+    "ac_kW": 5.0,
+    "ac_V": "240",
+    "phases": "1ph",
+    "max_system_vdc": 600,
+    "mppt_windows": [{"v_min": 200, "v_max": 550, "count": 2}]
+  },
+  {
+    "id": "INV_3_8K_2MPPT_600V",
+    "title": "String inverter 3.8 kW 240V, 2 MPPT, 600Vdc",
+    "ac_kW": 3.8,
+    "ac_V": "240",
+    "phases": "1ph",
+    "max_system_vdc": 600,
+    "mppt_windows": [{"v_min": 200, "v_max": 500, "count": 2}]
+  },
+  {
+    "id": "INV_7_6K_2MPPT_600V",
+    "title": "String inverter 7.6 kW 240V, 2 MPPT, 600Vdc",
+    "ac_kW": 7.6,
+    "ac_V": "240",
+    "phases": "1ph",
+    "max_system_vdc": 600,
+    "mppt_windows": [{"v_min": 200, "v_max": 550, "count": 2}]
+  }
+]

--- a/backend/tools/data/catalog/modules.json
+++ b/backend/tools/data/catalog/modules.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "MOD_400W",
+    "title": "Mono 400 W",
+    "p_W": 400,
+    "voc": 49.5,
+    "vmp": 41.5,
+    "isc": 11.2,
+    "imp": 10.7,
+    "beta_voc_pct_per_C": -0.28
+  },
+  {
+    "id": "MOD_450W",
+    "title": "Mono 450 W",
+    "p_W": 450,
+    "voc": 51.0,
+    "vmp": 42.5,
+    "isc": 11.5,
+    "imp": 10.9,
+    "beta_voc_pct_per_C": -0.28
+  }
+]

--- a/backend/tools/electrical_v2.py
+++ b/backend/tools/electrical_v2.py
@@ -1,0 +1,110 @@
+"""Minimal electrical v2 tools used by auto-designer tests.
+
+These are lightweight wrappers that emit annotation-only patches. They are
+placeholders until full electrical_v2 implementations are available."""
+from __future__ import annotations
+
+from typing import List
+from pydantic import BaseModel
+
+from backend.odl.schemas import PatchOp
+from backend.tools.schemas import ToolBase, make_patch
+
+
+class SelectOcpACV2Input(ToolBase):
+    inverter_inom_A: float
+
+
+def select_ocp_ac_v2(inp: SelectOcpACV2Input):
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:ocpac",
+            op="add_edge",
+            value={
+                "id": f"ann:ocpac:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "select_ocp_ac_v2", "inom_A": inp.inverter_inom_A},
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+
+
+class SelectConductorsV2Input(ToolBase):
+    circuit_kind: str
+    current_A: float
+    length_m: float
+    system_v: float
+
+
+def select_conductors_v2(inp: SelectConductorsV2Input):
+    ops = [
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:conductor",
+            op="add_edge",
+            value={
+                "id": f"ann:conductor:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {
+                    "tool": "select_conductors_v2",
+                    "kind": inp.circuit_kind,
+                    "current_A": inp.current_A,
+                },
+            },
+        )
+    ]
+    return make_patch(inp.request_id, ops)
+
+
+class ExpandConnectionsV2Input(ToolBase):
+    source_id: str
+    target_id: str
+    connection_type: str
+    add_ground: bool = False
+
+
+def expand_connections_v2(inp: ExpandConnectionsV2Input):
+    bundle_id = f"bundle:{inp.source_id}:{inp.target_id}:{inp.connection_type}"
+    ops: List[PatchOp] = []
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:edge:bundle",
+            op="add_edge",
+            value={
+                "id": bundle_id,
+                "source_id": inp.source_id,
+                "target_id": inp.target_id,
+                "kind": "bundle",
+                "attrs": {"system": inp.connection_type},
+            },
+        )
+    )
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:bundle",
+            op="add_edge",
+            value={
+                "id": f"ann:bundle:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "expand_connections_v2", "bundle_id": bundle_id},
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+
+
+__all__ = [
+    "SelectOcpACV2Input",
+    "select_ocp_ac_v2",
+    "SelectConductorsV2Input",
+    "select_conductors_v2",
+    "ExpandConnectionsV2Input",
+    "expand_connections_v2",
+]
+

--- a/backend/tools/materialize.py
+++ b/backend/tools/materialize.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+from typing import List, Dict
+from pydantic import BaseModel
+from backend.odl.schemas import PatchOp
+from backend.tools.schemas import ToolBase, make_patch
+
+
+class MaterializeDesignInput(ToolBase):
+    inverter_id: str
+    inverter_title: str
+    mppts: int
+    modules: int
+    modules_per_string: int
+    strings_parallel: int
+    create_edges: bool = True
+
+
+def _node(node_id: str, type_: str, label: str):
+    return {
+        "id": node_id,
+        "type": type_,
+        "label": label,
+        "ports": [{"id": "p1"}],
+        "attrs": {},
+    }
+
+
+def materialize_design(inp: MaterializeDesignInput):
+    ops: List[PatchOp] = []
+    if inp.simulate:
+        # Only annotate; no node/edge creation
+        ops.append(
+            PatchOp(
+                op_id=f"{inp.request_id}:ann:materialize.sim",
+                op="add_edge",
+                value={
+                    "id": f"ann:mat:{inp.request_id}",
+                    "source_id": "__decision__",
+                    "target_id": "__design__",
+                    "kind": "annotation",
+                    "attrs": {
+                        "tool": "materialize_design",
+                        "summary": f"(simulate) INV + {inp.modules} modules",
+                    },
+                },
+            )
+        )
+        return make_patch(inp.request_id, ops)
+
+    inv_node_id = "INV1"
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:add:inv",
+            op="add_node",
+            value=_node(inv_node_id, "string_inverter", inp.inverter_title),
+        )
+    )
+    # Module placeholders
+    for i in range(inp.modules):
+        nid = f"MOD{i+1}"
+        ops.append(
+            PatchOp(
+                op_id=f"{inp.request_id}:add:mod:{i+1}",
+                op="add_node",
+                value=_node(nid, "pv_module", f"Module {i+1}"),
+            )
+        )
+    # Simple SLD edges: connect series strings to inverter MPPT A/B...
+    if inp.create_edges:
+        # connect every module to inverter logically; downstream tools will expand
+        for i in range(inp.modules):
+            ops.append(
+                PatchOp(
+                    op_id=f"{inp.request_id}:edge:mod:{i+1}",
+                    op="add_edge",
+                    value={
+                        "id": f"MOD{i+1}->INV1",
+                        "source_id": f"MOD{i+1}",
+                        "target_id": inv_node_id,
+                        "kind": "logical",
+                        "attrs": {"note": "string placeholder"},
+                    },
+                )
+            )
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:materialize",
+            op="add_edge",
+            value={
+                "id": f"ann:materialize:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {
+                    "tool": "materialize_design",
+                    "summary": f"Created 1 inverter + {inp.modules} modules",
+                },
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+
+
+__all__ = ["MaterializeDesignInput", "materialize_design"]
+

--- a/backend/tools/ocp_dc.py
+++ b/backend/tools/ocp_dc.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from typing import Dict, List
+from pydantic import BaseModel
+from backend.odl.schemas import PatchOp
+from backend.tools.schemas import ToolBase, make_patch
+
+
+class Module(BaseModel):
+    isc: float
+
+
+class SelectOcpDcInput(ToolBase):
+    strings_parallel: int
+    module: Module
+
+
+def select_ocp_dc(inp: SelectOcpDcInput):
+    findings = []
+    result: Dict = {"string_fusing_required": False, "fuse_A": None}
+    if inp.strings_parallel >= 3:
+        result["string_fusing_required"] = True
+        # Rule-of-thumb: ≥ 1.25× Isc at expected temperature; keep simple here
+        fuse = int(round(max(15, 1.25 * inp.module.isc)))
+        # round up to standard size
+        std = [10, 15, 20, 25, 30]
+        result["fuse_A"] = min([s for s in std if s >= fuse] or [30])
+    ops: List[PatchOp] = []
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:ocpdc",
+            op="add_edge",
+            value={
+                "id": f"ann:ocpdc:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {"tool": "select_ocp_dc", "result": result, "findings": findings},
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+
+
+__all__ = ["Module", "SelectOcpDcInput", "select_ocp_dc"]
+

--- a/backend/tools/schemas.py
+++ b/backend/tools/schemas.py
@@ -22,6 +22,9 @@ class ToolBase(BaseModel):
 
     session_id: str = Field(..., description="Design session id")
     request_id: str = Field(..., description="Idempotency scope for op_ids")
+    # Soft default: tools may run in simulate mode (compute & annotate only).
+    # Creation tools MUST honor this (no graph mutations when simulate=True).
+    simulate: bool = False
     model_config = ConfigDict(extra="forbid")
 
 

--- a/backend/tools/select_equipment.py
+++ b/backend/tools/select_equipment.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+from typing import List, Dict, Any
+from pydantic import BaseModel
+from backend.odl.schemas import PatchOp
+from backend.tools.schemas import ToolBase, make_patch
+from backend.tools.catalog import load_modules, load_inverters, ModuleItem, InverterItem
+
+
+class SelectEquipmentInput(ToolBase):
+    target_kw_stc: float
+    preferred_module_W: float | None = None
+    inverter_kw_window: tuple[float, float] = (0.7, 1.2)  # inverter AC size relative to DC target
+
+
+def _choose_module(target_kw: float, preferred_W: float | None, modules: List[ModuleItem]) -> ModuleItem:
+    if preferred_W:
+        byW = sorted(modules, key=lambda m: abs(m.p_W - preferred_W))
+        return byW[0]
+    # Pick mid-bin module
+    return sorted(modules, key=lambda m: abs(m.p_W - 400))[0]
+
+
+def _choose_inverter(target_kw: float, window: tuple[float, float], inverters: List[InverterItem]) -> InverterItem:
+    lo = target_kw * window[0]
+    hi = target_kw * window[1]
+    # Prefer the smallest inverter within window; fallback to nearest above
+    cands = [i for i in inverters if lo <= i.ac_kW <= hi]
+    if not cands:
+        above = [i for i in inverters if i.ac_kW >= lo]
+        return sorted(above, key=lambda i: i.ac_kW)[0] if above else sorted(inverters, key=lambda i: i.ac_kW)[-1]
+    return sorted(cands, key=lambda i: i.ac_kW)[0]
+
+
+def select_equipment(inp: SelectEquipmentInput):
+    mods = load_modules()
+    invs = load_inverters()
+    m = _choose_module(inp.target_kw_stc, inp.preferred_module_W, mods)
+    inv = _choose_inverter(inp.target_kw_stc, inp.inverter_kw_window, invs)
+    equip = {
+        "module": m.__dict__,
+        "inverter": {
+            **inv.__dict__,
+            "mppt_count": sum(w.get("count", 1) for w in inv.mppt_windows),
+        },
+    }
+    ops: List[PatchOp] = []
+    # Persist to meta.design_state.equip (state only)
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:meta:equip",
+            op="set_meta",
+            value={"path": "design_state.equip", "merge": True, "data": equip},
+        )
+    )
+    # Annotation
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:equip",
+            op="add_edge",
+            value={
+                "id": f"ann:equip:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {
+                    "tool": "select_equipment",
+                    "summary": f"{m.title} + {inv.title}",
+                },
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+
+
+__all__ = ["SelectEquipmentInput", "select_equipment"]
+

--- a/backend/tools/stringing.py
+++ b/backend/tools/stringing.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+from math import ceil
+from typing import Dict, List
+from pydantic import BaseModel
+from backend.odl.schemas import PatchOp
+from backend.tools.schemas import ToolBase, make_patch
+
+
+class Env(BaseModel):
+    site_tmin_C: float
+
+
+class Module(BaseModel):
+    p_W: float
+    voc: float
+    vmp: float
+    imp: float
+    beta_voc_pct_per_C: float
+
+
+class MpptWindow(BaseModel):
+    v_min: float
+    v_max: float
+    count: int = 1
+
+
+class Inverter(BaseModel):
+    max_system_vdc: float
+    mppt_windows: List[MpptWindow]
+
+
+class SelectStringingInput(ToolBase):
+    target_kw_stc: float
+    env: Env
+    module: Module
+    inverter: Inverter
+    margin_voc_pct: float = 0.02  # headroom vs system Vdc
+
+
+def _voc_cold(voc_stc: float, beta_pct_perC: float, tmin: float, ref: float = 25.0) -> float:
+    dv = beta_pct_perC * (tmin - ref)
+    return voc_stc * (1.0 + dv / 100.0)
+
+
+def select_dc_stringing(inp: SelectStringingInput):
+    target_W = inp.target_kw_stc * 1000
+    n_modules = max(1, round(target_W / inp.module.p_W))
+
+    voc_cold = _voc_cold(inp.module.voc, inp.module.beta_voc_pct_per_C, inp.env.site_tmin_C)
+    sys_lim = inp.inverter.max_system_vdc * (1.0 - inp.margin_voc_pct)
+    # Pick max N satisfying Voc_cold*N <= sys_lim and Vmp*N within any MPPT window
+    best = None
+    for N in range(4, 20):  # practical residential range
+        vocN = voc_cold * N
+        vmpN = inp.module.vmp * N
+        if vocN > sys_lim:
+            break
+        fits = any(w.v_min <= vmpN <= w.v_max for w in inp.inverter.mppt_windows)
+        if not fits:
+            continue
+        best = N
+    if best is None:
+        # fallback: smallest N under system voltage
+        for N in range(2, 20):
+            if voc_cold * N <= sys_lim:
+                best = N
+                break
+    N = best or 6
+    S_total = ceil(n_modules / N)
+    mppt_total = sum(w.count for w in inp.inverter.mppt_windows)
+    # spread strings across MPPTs as evenly as possible
+    alloc = [0] * mppt_total
+    for i in range(S_total):
+        alloc[i % mppt_total] += 1
+
+    strings = {
+        "series": N,
+        "parallel": S_total,
+        "mppt_allocation": alloc,
+        "array_modules": int(N * S_total),
+        "array_kw_stc": round((N * S_total * inp.module.p_W) / 1000, 3),
+        "voc_cold_string_V": round(voc_cold * N, 2),
+        "vmp_string_V": round(inp.module.vmp * N, 2),
+    }
+    ops: List[PatchOp] = []
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:meta:strings",
+            op="set_meta",
+            value={"path": "design_state.strings", "merge": True, "data": strings},
+        )
+    )
+    ops.append(
+        PatchOp(
+            op_id=f"{inp.request_id}:ann:strings",
+            op="add_edge",
+            value={
+                "id": f"ann:strings:{inp.request_id}",
+                "source_id": "__decision__",
+                "target_id": "__design__",
+                "kind": "annotation",
+                "attrs": {
+                    "tool": "select_dc_stringing",
+                    "summary": f"N={N}, S={S_total}, Voc_cold={strings['voc_cold_string_V']} V",
+                },
+            },
+        )
+    )
+    return make_patch(inp.request_id, ops)
+
+
+__all__ = [
+    "Env",
+    "Module",
+    "Inverter",
+    "MpptWindow",
+    "SelectStringingInput",
+    "select_dc_stringing",
+]
+


### PR DESCRIPTION
## Summary
- add PlanSpec schema and auto_designer orchestrator for PV system design
- add equipment catalog and selection, stringing, DC OCPD, materialization, and BOM tools
- extend router with new tools and phase gating; include lightweight electrical_v2 stubs

## Testing
- `pytest backend/tests/test_auto_designer.py backend/tests/test_selection_and_stringing.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab93d402208329b83383f836a8389c