### PR TITLE
Expose attribute_catalog_service in services package

### DIFF
--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -8,5 +8,6 @@ non-installed test environments.
 # minimal to avoid heavy side effects during test discovery.
 from . import odl_graph_service  # noqa: F401
 from . import ai as ai  # noqa: F401
+from . import attribute_catalog_service  # noqa: F401
 
-__all__ = ["odl_graph_service", "ai"]
+__all__ = ["odl_graph_service", "ai", "attribute_catalog_service"]


### PR DESCRIPTION
## Summary
- re-export attribute_catalog_service in backend.services package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest backend/tests/test_component_db_service.py::test_get_by_part_number -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba7086de4832993287c7233902a50